### PR TITLE
Preserve empty JSON arrays

### DIFF
--- a/lua/claude_handler.lua
+++ b/lua/claude_handler.lua
@@ -5,7 +5,8 @@
 -- sends through the E2EE pipeline, and translates responses back.
 --
 
-local cjson = require("cjson.safe")
+local cjson = require("cjson.safe").new()
+cjson.decode_array_with_array_mt(true)
 local e2ee = require("e2ee_handler")
 local claude_fmt = require("claude_format")
 

--- a/lua/e2ee_crypto.lua
+++ b/lua/e2ee_crypto.lua
@@ -10,6 +10,8 @@ local base64 = require("ngx.base64") or {
     encode_base64 = ngx.encode_base64,
     decode_base64 = ngx.decode_base64,
 }
+local cjson = require("cjson").new()
+cjson.decode_array_with_array_mt(true)
 
 ffi.cdef[[
     int e2ee_init(void);
@@ -211,7 +213,6 @@ function _M.build_e2ee_request(e2e_pubkey_b64, payload_json)
     if not sym_key then return nil, nil, err end
 
     -- 5. Augment payload with response public key
-    local cjson = require("cjson")
     local payload = cjson.decode(payload_json)
     payload["e2e_response_pk"] = ngx.encode_base64(ffi.string(response_pk, 1184))
     local augmented_json = cjson.encode(payload)

--- a/lua/responses_handler.lua
+++ b/lua/responses_handler.lua
@@ -5,7 +5,8 @@
 -- sends through the E2EE pipeline, and translates responses back.
 --
 
-local cjson = require("cjson.safe")
+local cjson = require("cjson.safe").new()
+cjson.decode_array_with_array_mt(true)
 local e2ee = require("e2ee_handler")
 local resp_fmt = require("responses_format")
 

--- a/tests/test_json_array_roundtrip.lua
+++ b/tests/test_json_array_roundtrip.lua
@@ -1,0 +1,96 @@
+package.path = "./lua/?.lua;/workspace/lua/?.lua;" .. package.path
+
+local function serializer_for(func)
+    for index = 1, 20 do
+        local name, value = debug.getupvalue(func, index)
+        if not name then
+            break
+        end
+        if name == "cjson" then
+            return value
+        end
+    end
+    error("production serializer not found")
+end
+
+local function assert_schema_types(encoded, path)
+    assert(encoded:find('"required":[]', 1, true), path .. ": empty array became an object")
+    assert(encoded:find('"properties":{}', 1, true), path .. ": empty object became an array")
+end
+
+local function assert_safe_decode(cjson, path)
+    local value, err = cjson.decode("{")
+    assert(value == nil and err, path .. ": invalid JSON raised instead of returning an error")
+end
+
+local chat_json = [[
+{
+    "tools": [{
+        "type": "function",
+        "function": {
+            "name": "list_files",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    }]
+}
+]]
+
+local crypto = require("e2ee_crypto")
+local crypto_json = serializer_for(crypto.build_e2ee_request)
+local chat_payload = crypto_json.decode(chat_json)
+chat_payload.e2e_response_pk = "test-key"
+assert_schema_types(crypto_json.encode(chat_payload), "chat completions")
+
+local claude_handler = require("claude_handler")
+local claude_format = require("claude_format")
+local claude_json = serializer_for(claude_handler.handle)
+assert_safe_decode(claude_json, "Claude Messages")
+local claude_payload = claude_json.decode([[
+{
+    "model": "test-model",
+    "max_tokens": 1,
+    "messages": [{"role": "user", "content": "test"}],
+    "tools": [{
+        "name": "list_files",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    }]
+}
+]])
+assert_schema_types(
+    claude_json.encode(claude_format.request_to_openai(claude_payload)),
+    "Claude Messages"
+)
+
+local responses_handler = require("responses_handler")
+local responses_format = require("responses_format")
+local responses_json = serializer_for(responses_handler.handle)
+assert_safe_decode(responses_json, "Responses API")
+local responses_payload = responses_json.decode([[
+{
+    "model": "test-model",
+    "input": "test",
+    "tools": [{
+        "type": "function",
+        "name": "list_files",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    }]
+}
+]])
+assert_schema_types(
+    responses_json.encode(responses_format.request_to_openai(responses_payload)),
+    "Responses API"
+)
+
+print("JSON array round-trip tests passed")


### PR DESCRIPTION
## Summary
- Preserve empty JSON arrays across E2EE request translation.
- Cover Chat Completions, Claude Messages, and Responses API.

## Why
Lua cjson changed `required: []` into `{}`, causing SGLang tool requests to return 400.

## Validation
- JSON round-trip regression test
- Live E2EE tool requests across all three APIs
